### PR TITLE
Add hierarchical support to alternating transformer

### DIFF
--- a/src/gluonts/mx/model/alternatingtransformer/_estimator.py
+++ b/src/gluonts/mx/model/alternatingtransformer/_estimator.py
@@ -50,6 +50,8 @@ from ._network import (
     AlternatingTransformerNetwork,
     AlternatingTransformerTrainingNetwork,
     AlternatingTransformerPredictionNetwork,
+    AlternatingTransformerHierarchicalTrainingNetwork,
+    AlternatingTransformerHierarchicalPredictionNetwork,
 )
 
 
@@ -71,6 +73,8 @@ class AlternatingTransformerEstimator(GluonEstimator):
         validation_sampler: Optional[InstanceSampler] = None,
         batch_size: int = 32,
         debug: bool = False,
+        S: Optional[mx.nd.NDArray] = None,
+        loss: str = "mse",
     ) -> None:
         super().__init__(trainer=trainer, batch_size=batch_size)
 
@@ -83,6 +87,8 @@ class AlternatingTransformerEstimator(GluonEstimator):
         self.distr_output = distr_output
         self.num_parallel_samples = num_parallel_samples
         self.debug = debug
+        self.S = S
+        self.loss = loss
         self.train_sampler = (
             train_sampler
             if train_sampler is not None
@@ -179,6 +185,14 @@ class AlternatingTransformerEstimator(GluonEstimator):
             config=self.config,
             debug=self.debug,
         )
+        if self.S is not None:
+            return AlternatingTransformerHierarchicalTrainingNetwork(
+                base_network=base_net,
+                prediction_length=self.prediction_length,
+                S=self.S,
+                loss=self.loss,
+                distr_output=self.distr_output,
+            )
         return AlternatingTransformerTrainingNetwork(
             base_network=base_net,
             prediction_length=self.prediction_length,
@@ -195,13 +209,24 @@ class AlternatingTransformerEstimator(GluonEstimator):
             config=self.config,
             debug=self.debug,
         )
-        prediction_network = AlternatingTransformerPredictionNetwork(
-            base_network=base_net,
-            prediction_length=self.prediction_length,
-            distr_output=self.distr_output,
-            num_samples=self.num_parallel_samples,
-            params=trained_network.collect_params(),
-        )
+        if self.S is not None:
+            prediction_network = AlternatingTransformerHierarchicalPredictionNetwork(
+                base_network=base_net,
+                prediction_length=self.prediction_length,
+                S=self.S,
+                loss=self.loss,
+                distr_output=self.distr_output,
+                num_samples=self.num_parallel_samples,
+                params=trained_network.collect_params(),
+            )
+        else:
+            prediction_network = AlternatingTransformerPredictionNetwork(
+                base_network=base_net,
+                prediction_length=self.prediction_length,
+                distr_output=self.distr_output,
+                num_samples=self.num_parallel_samples,
+                params=trained_network.collect_params(),
+            )
         prediction_splitter = self._create_instance_splitter("test")
         return RepresentableBlockPredictor(
             input_transform=transformation + prediction_splitter,

--- a/src/gluonts/mx/model/alternatingtransformer/_network.py
+++ b/src/gluonts/mx/model/alternatingtransformer/_network.py
@@ -14,12 +14,14 @@
 """Networks used by the Alternating Transformer model."""
 
 from typing import Dict
+from itertools import product
 
 import mxnet as mx
 from mxnet.gluon import HybridBlock, nn
 
 from gluonts.core.component import validated
 from gluonts.mx import Tensor
+from gluonts.mx.distribution import EmpiricalDistribution
 
 from .layers import AlternatingTransformerLayer
 
@@ -139,3 +141,136 @@ class AlternatingTransformerPredictionNetwork(
     ) -> Tensor:
         distr = super().hybrid_forward(F, data, spatial_token, temporal_token)
         return distr.sample(num_samples=self.num_samples)
+
+
+def reconcile_samples(
+    reconciliation_mat: Tensor, samples: Tensor, seq_axis=None
+) -> Tensor:
+    """Project ``samples`` using ``reconciliation_mat`` as done in the
+    hierarchical DeepVAR model."""
+    if not seq_axis:
+        return mx.nd.dot(samples, reconciliation_mat, transpose_b=True)
+    num_dims = len(samples.shape)
+    last_dim_in_seq_axis = num_dims - 1 in seq_axis or -1 in seq_axis
+    assert not last_dim_in_seq_axis, (
+        "The last dimension cannot be processed iteratively. Remove axis"
+        f" {num_dims - 1} (or -1) from `seq_axis`."
+    )
+    num_seq_axes = len(seq_axis)
+    samples = mx.nd.moveaxis(samples, seq_axis, list(range(num_seq_axes)))
+    seq_axes_sizes = samples.shape[:num_seq_axes]
+    out = [
+        mx.nd.dot(samples[idx], reconciliation_mat, transpose_b=True)
+        for idx in product(*[range(size) for size in seq_axes_sizes])
+    ]
+    out = mx.nd.concat(*out, dim=0).reshape(samples.shape)
+    out = mx.nd.moveaxis(out, list(range(len(seq_axis))), seq_axis)
+    return out
+
+
+class PredictionHead(HybridBlock):
+    """Simple prediction head to allow deterministic or probabilistic outputs."""
+
+    @validated()
+    def __init__(self, output_dim: int, distr_output=None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.probabilistic = distr_output is not None
+        with self.name_scope():
+            if self.probabilistic:
+                self.proj = distr_output.get_args_proj()
+                self.distr_output = distr_output
+            else:
+                self.proj = nn.Dense(units=output_dim, flatten=False)
+
+    def hybrid_forward(self, F, x: Tensor) -> Tensor:
+        out = self.proj(x)
+        if self.probabilistic:
+            return self.distr_output.distribution(out)
+        return out
+
+
+class AlternatingTransformerHierarchicalTrainingNetwork(HybridBlock):
+    """Training network forecasting bottom level and reconciling outputs."""
+
+    @validated()
+    def __init__(
+        self,
+        base_network: AlternatingTransformerNetwork,
+        prediction_length: int,
+        S: mx.nd.NDArray,
+        loss: str = "mse",
+        distr_output=None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.prediction_length = prediction_length
+        self.base_network = base_network
+        self.S = S
+        self.loss = loss
+        self.num_bottom = int(S.shape[1])
+        with self.name_scope():
+            self.head = PredictionHead(self.num_bottom, distr_output)
+
+    def hybrid_forward(
+        self, F, data: Tensor, spatial_token: Tensor, temporal_token: Tensor, target: Tensor
+    ) -> Tensor:
+        features = self.base_network(data, spatial_token, temporal_token)
+        pred = F.slice_axis(features, axis=2, begin=-self.prediction_length, end=None)
+        bottom_feat = F.slice_axis(pred, axis=1, begin=-self.num_bottom, end=None)
+        out = self.head(bottom_feat)
+
+        target = F.slice_axis(target, axis=2, begin=-self.prediction_length, end=None)
+        target_bottom = F.slice_axis(target, axis=1, begin=-self.num_bottom, end=None)
+
+        if isinstance(out, mx.gluon.HybridBlock):
+            raise RuntimeError("unexpected block returned by prediction head")
+
+        if self.head.probabilistic:
+            distr = out
+            samples = distr.sample(num_samples=100)
+            samples = samples.swapaxes(0, 1)
+            samples_full = reconcile_samples(self.S.T, samples)
+            crps = (
+                EmpiricalDistribution(samples=samples_full, event_dim=1)
+                .crps_univariate(x=target)
+                .expand_dims(axis=-1)
+            )
+            return crps
+        else:
+            preds = out
+            preds = preds.swapaxes(1, 2)
+            full = F.linalg_gemm2(preds, self.S.T)
+            if self.loss == "mae":
+                return F.abs(full - target).mean(axis=1, keepdims=True)
+            else:
+                return F.square(full - target).mean(axis=1, keepdims=True)
+
+
+class AlternatingTransformerHierarchicalPredictionNetwork(
+    AlternatingTransformerHierarchicalTrainingNetwork
+):
+    """Prediction network generating coherent samples."""
+
+    @validated()
+    def __init__(self, num_samples: int = 100, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.num_samples = num_samples
+
+    def hybrid_forward(
+        self, F, data: Tensor, spatial_token: Tensor, temporal_token: Tensor, target: Tensor = None
+    ) -> Tensor:
+        features = self.base_network(data, spatial_token, temporal_token)
+        pred = F.slice_axis(features, axis=2, begin=-self.prediction_length, end=None)
+        bottom_feat = F.slice_axis(pred, axis=1, begin=-self.num_bottom, end=None)
+        out = self.head(bottom_feat)
+
+        if self.head.probabilistic:
+            distr = out
+            samples = distr.sample(num_samples=self.num_samples)
+            samples = samples.swapaxes(0, 1)
+            samples_full = reconcile_samples(self.S.T, samples)
+            return samples_full
+        else:
+            preds = out.swapaxes(1, 2)
+            full = F.linalg_gemm2(preds, self.S.T)
+            return F.expand_dims(full, axis=0)


### PR DESCRIPTION
## Summary
- extend alternatingtransformer networks with prediction heads
- add helper for sample reconciliation
- support hierarchical training and prediction in the estimator

## Testing
- `python -m py_compile src/gluonts/mx/model/alternatingtransformer/_network.py`
- `python -m py_compile src/gluonts/mx/model/alternatingtransformer/_estimator.py`
- `pytest -k alternatingtransformer -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e62e3b7248325a87d020f686c84de